### PR TITLE
Implementation of Dimension Confirmaton

### DIFF
--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -146,7 +146,7 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
       {
         for(i in 1:length(uniq))
           {
-            target.dim <- boot.wc[[m]]$membership[which(confirm==i)]
+            target.dim <- boot.wc[[m]]$membership[which(confirm==uniq[i])]
             uniq.dim <- unique(target.dim)
             if(length(uniq.dim)==1){confirm.dim[m,i] <- 1}else{confirm.dim[m,i] <- 0}
           }


### PR DESCRIPTION
Implemented an argument "confirm" to count the number of times each community is found in the bootstrapped samples. In this way, the stability of each specific dimension is checked, which allows for an examination of dimension consistency.

A notable consequence of this statistic is that it allows inferences into which dimensions are less stable, signifying that they converge into one dimension (or diverge into two) based on different bootstrapped samples. Thus, there is some potential for this to be used a tool to identify dimensions that could possibly be more homogeneous (or more heterogeneous) compared to the original findings.

A word of caution: The labels for the output are associated with the input dimensions and not the median dimensions produced in the figure.