### PR TITLE
Dimension and Item Confirmation Functionality

### DIFF
--- a/R/EGA.R
+++ b/R/EGA.R
@@ -11,6 +11,8 @@
 #' \code{TMFG}:
 #' {Estimates a Triangulated Maximally Filtered Graph, using the function \code{\link[NetworkToolbox]{TMFG}} of the \code{\link[NetworkToolbox]{NetworkToolbox}} package}
 #' @param n Integer. Sample size, if the data provided is a correlation matrix.
+#' @param steps Number of steps to be used in walktrap algorithm.
+#' Defaults to 4
 #' @author Hudson F. Golino <hfg9s at virginia.edu>
 #' @examples
 #' ega.wmt <- EGA(data = wmt2[,7:24], model = "glasso", plot.EGA = TRUE)
@@ -29,7 +31,7 @@
 #' @export
 
 # EGA default function - 11/21/2017
-EGA <- function(data, model = c("glasso", "TMFG"), plot.EGA = TRUE, n = NULL) {
+EGA <- function(data, model = c("glasso", "TMFG"), plot.EGA = TRUE, n = NULL, steps = 4) {
   if(!require(qgraph)) {
     message("installing the 'qgraph' package")
     install.packages("qgraph")
@@ -69,7 +71,7 @@ EGA <- function(data, model = c("glasso", "TMFG"), plot.EGA = TRUE, n = NULL) {
   }
 
     graph <- as.igraph(qgraph(abs(estimated.network), layout = "spring", vsize = 3, DoNotPlot = TRUE))
-    wc <- walktrap.community(graph)
+    wc <- walktrap.community(graph, steps = steps)
     n.dim <- max(wc$membership)
     a <- list()
     a$n.dim <- n.dim

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -158,18 +158,17 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
             target.dim <- boot.wc[[m]]$membership[dim.items]
             uniq.dim <- unique(target.dim)
             if(length(uniq.dim)==1){confirm.dim[m,i] <- 1}else{confirm.dim[m,i] <- 0}
+            
+            #Check if item is confirmed within dimension
+            if(length(uniq.dim)>1)
+              {
+                target.mode <- mode(target.dim)
+                non.con <- dim.items[which(target.dim!=target.mode)]
+                con <- setdiff(dim.items,non.con)
+                item.confirm[m,non.con] <- 0
+                item.confirm[m,con] <- 1
+              } else {item.confirm[m,dim.items] <- 1}
           }
-      
-        #Check if item is confirmed within dimension
-        if(length(uniq.dim)>1)
-          {
-            target.mode <- mode(target.dim)
-            non.con <- dim.items[which(target.dim!=target.mode)]
-            con <- setdiff(dim.items,non.con)
-            item.confirm[m,non.con] <- 0
-            item.confirm[m,con] <- 1
-          } else {item.confirm[m,dim.items] <- 1}
-        
       }
   }
   

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -145,13 +145,23 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
       confirm.dim <- matrix(NA, nrow = n, ncol = length(uniq))
       item.confirm <- matrix(NA, nrow = n, ncol = ncol(data))
       dim.nmi <- vector("numeric", length = n)
+    
+      #check if confirm is character
+      if(is.character(confirm))
+        {
+            uni <- unique(confirm)
+            num.comm <- confirm
+            
+            for(i in 1:length(uni))
+            {num.comm[which(num.comm==uniq[i])] <- i}
+        } else {num.comm <- confirm} 
     }
   
   for (m in 1:n) {
     boot.ndim[m, 2] <- max(boot.wc[[m]]$membership)
     
     #normalized mutual information of community comparisons
-    dim.nmi[m] <- igraph::compare(boot.wc[[m]]$membership, confirm, method="nmi")
+    dim.nmi[m] <- igraph::compare(boot.wc[[m]]$membership, num.comm, method="nmi")
         
     #Check if dimension is confirmed
     if(!is.null(confirm))
@@ -188,8 +198,8 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
     
       #Tables for nmi
       dim.nmi.table <- vector("numeric", length = 2)
-      dim.nmi.table[1] <- mean(dim.nmi, na.rm = TRUE)
-      dim.nmi.table[2] <- sd(dim.nmi, na.rm = TRUE)
+      dim.nmi.table[1] <- mean(dim.nmi)
+      dim.nmi.table[2] <- sd(dim.nmi)
       names(dim.nmi.table) <- c("mean","sd")
     }
   

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -146,7 +146,7 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
       {
         for(i in 1:length(uniq))
           {
-            target.dim <- boot.wc[[m]]$membership[which(confirm==i)]
+            target.dim <- boot.wc[[m]]$membership[which(confirm==uniq[i])]
             uniq.dim <- unique(target.dim)
             if(length(uniq.dim)==1){confirm.dim[m,i] <- 1}else{confirm.dim[m,i] <- 0}
           }

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -149,6 +149,9 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
   for (m in 1:n) {
     boot.ndim[m, 2] <- max(boot.wc[[m]]$membership)
     
+    #normalized mutual information of community comparisons
+    dim.nmi[m] <- igraph::compare(boot.wc[[m]]$membership,confirm,method="nmi")
+        
     #Check if dimension is confirmed
     if(!is.null(confirm))
       {
@@ -181,6 +184,12 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
       #Proportion of times item is confirmed
       con.item <- (colSums(item.confirm)/n)
       names(con.item) <- colnames(data)
+    
+      #Tables for nmi
+      dim.nmi.table <- vector("numeric", length = 2)
+      dim.nmi.table[1] <- mean(dim.nmi)
+      dim.nmi.table[2] <- sd(dim.nmi)
+      names(dim.nmi.table) <- c("mean","sd")
     }
   
   colnames(boot.ndim) <- c("Boot.Number", "N.Dim")
@@ -231,6 +240,7 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
   {
     result$dim.confirm <- con.dim
     result$item.confirm <- con.item
+    result$dim.nmi <- dim.nmi.table
   }
   typicalGraph <- list()
   typicalGraph$graph <- typical.Structure

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -143,7 +143,7 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
     {
       uniq <- unique(confirm)
       confirm.dim <- matrix(NA, nrow = n, ncol = length(uniq))
-      confirm.item <- matrix(NA, nrow = n, ncol = ncol(data))
+      item.confirm <- matrix(NA, nrow = n, ncol = ncol(data))
     }
   
   for (m in 1:n) {

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -144,13 +144,14 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
       uniq <- unique(confirm)
       confirm.dim <- matrix(NA, nrow = n, ncol = length(uniq))
       item.confirm <- matrix(NA, nrow = n, ncol = ncol(data))
+      dim.nmi <- vector("numeric", length = n)
     }
   
   for (m in 1:n) {
     boot.ndim[m, 2] <- max(boot.wc[[m]]$membership)
     
     #normalized mutual information of community comparisons
-    dim.nmi[m] <- igraph::compare(boot.wc[[m]]$membership,confirm,method="nmi")
+    dim.nmi[m] <- igraph::compare(boot.wc[[m]]$membership, confirm, method="nmi")
         
     #Check if dimension is confirmed
     if(!is.null(confirm))
@@ -187,8 +188,8 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
     
       #Tables for nmi
       dim.nmi.table <- vector("numeric", length = 2)
-      dim.nmi.table[1] <- mean(dim.nmi)
-      dim.nmi.table[2] <- sd(dim.nmi)
+      dim.nmi.table[1] <- mean(dim.nmi, na.rm = TRUE)
+      dim.nmi.table[2] <- sd(dim.nmi, na.rm = TRUE)
       names(dim.nmi.table) <- c("mean","sd")
     }
   

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -154,7 +154,8 @@ bootEGA <- function(data, n, typicalStructure = TRUE, plot.typicalStructure = TR
       {
         for(i in 1:length(uniq))
           {
-            target.dim <- boot.wc[[m]]$membership[which(confirm==uniq[i])]
+            dim.items <- which(confirm==uniq[i])
+            target.dim <- boot.wc[[m]]$membership[dim.items]
             uniq.dim <- unique(target.dim)
             if(length(uniq.dim)==1){confirm.dim[m,i] <- 1}else{confirm.dim[m,i] <- 0}
           }


### PR DESCRIPTION
UPDATED:

**New argument "confirm"**
Allows the user to input a vector to confirm identified communities

**Within the script**
Each dimension is counted for how often in replicates in the bootstraps.
The sum for each dimension is taken and divided by the number of bootstraps.

Each item is counted for how often it replicates within the original dimension.
The sum for each item is taken and divided by the number of bootstraps.

**Output**
The proportion of times the dimension replicates across bootstraps.

The proportion of times the item replicates within its specified dimension across bootstraps.


**Take-home**
The stability of each dimension is gained, suggesting which dimensions appear most frequently and are stable. Problematic dimensions can be identified (ones that are more heterogeneous or have items that are not consistent within the dimension).

The item confirmation functionality is complementary to the stability of dimensions. Problematic dimensions can further be specified down to which items are problematic for community identification. These items might be falling into different communities depending upon the bootstrapped sample, suggesting the item is between two dimensions and may represent both (a multidimensional item) rather than one dimension.